### PR TITLE
Add renovate.json to enable automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "tekton": {
+    "fileMatch": ["\\.yaml$", "\\.yml$"],
+    "includePaths": ["pipelines/**", "tasks/**"],
+    "automerge": true
+  }
+}


### PR DESCRIPTION
Changes:
- Add renovate.json to extend renovate-bot configuration
- Enable "automerge" for tekton manager (pipelines and tasks)