### PR TITLE
Fix pipeline ref for pull request

### DIFF
--- a/.tekton/openshift-builds-fbc-test.yaml
+++ b/.tekton/openshift-builds-fbc-test.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "1"
+    pipelinesascode.tekton.dev/pipeline: "pipelines/konflux-build-fbc.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "main" &&
@@ -40,14 +41,7 @@ spec:
         - linux/x86_64
         - linux/arm64
   pipelineRef:
-    resolver: git
-    params:
-      - name: url
-        value: https://github.com/redhat-openshift-builds/release.git
-      - name: revision
-        value: main
-      - name: pathInRepo
-        value: /pipelines/konflux-build-fbc.yaml
+    name: konflux-build-fbc
   taskRunTemplate: {}
   workspaces:
     - name: git-auth

--- a/.tekton/openshift-builds-operator-bundle-test.yaml
+++ b/.tekton/openshift-builds-operator-bundle-test.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "1"
+    pipelinesascode.tekton.dev/pipeline: "pipelines/konflux-build.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "main" &&
@@ -40,14 +41,7 @@ spec:
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineRef:
-    resolver: git
-    params:
-      - name: url
-        value: https://github.com/redhat-openshift-builds/release.git
-      - name: revision
-        value: main
-      - name: pathInRepo
-        value: /pipelines/konflux-build-multi-platform.yaml
+    name: konflux-build
   taskRunTemplate: {}
   workspaces:
     - name: git-auth

--- a/.tekton/openshift-builds-operator-test.yaml
+++ b/.tekton/openshift-builds-operator-test.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "1"
+    pipelinesascode.tekton.dev/pipeline: "pipelines/konflux-build-multi-platform.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "main" &&
@@ -44,14 +45,7 @@ spec:
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineRef:
-    resolver: git
-    params:
-      - name: url
-        value: https://github.com/redhat-openshift-builds/release.git
-      - name: revision
-        value: main
-      - name: pathInRepo
-        value: /pipelines/konflux-build-multi-platform.yaml
+    name: konflux-build-multi-platform
   taskRunTemplate: {}
   workspaces:
     - name: git-auth


### PR DESCRIPTION
## Changes:
Currently the pull request pipeline references the build pipelines from main branch, which is incorrect because the build pipeline changes in the pull request will not be tested with the pull request. Now the reference is changed to fetch the pipeline from the pull request itself.