### PR TITLE
Use a separate pipeline for bundle build

### DIFF
--- a/.tekton/openshift-builds-operator-bundle-test.yaml
+++ b/.tekton/openshift-builds-operator-bundle-test.yaml
@@ -7,12 +7,12 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "1"
-    pipelinesascode.tekton.dev/pipeline: "pipelines/konflux-build.yaml"
+    pipelinesascode.tekton.dev/pipeline: "pipelines/konflux-build-bundle.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "main" &&
       (
-        files.all.exists(x, x.matches('pipelines/konflux-build.yaml')) ||
+        files.all.exists(x, x.matches('pipelines/konflux-build-bundle.yaml')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-operator-bundle-test.yaml'))
       )
   labels:
@@ -41,7 +41,7 @@ spec:
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineRef:
-    name: konflux-build
+    name: konflux-build-bundle
   taskRunTemplate: {}
   workspaces:
     - name: git-auth

--- a/pipelines/konflux-build-bundle.yaml
+++ b/pipelines/konflux-build-bundle.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: konflux-build
+  name: konflux-build-bundle
 spec:
   finally:
   - name: show-sbom
@@ -366,26 +366,6 @@ spec:
         value: clair-scan
       - name: bundle
         value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:712afcf63f3b5a97c371d37e637efbcc9e1c7ad158872339d00adc6413cd8851
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values:
-      - "false"
-  - name: ecosystem-cert-preflight-checks
-    params:
-    - name: image-url
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    runAfter:
-    - build-image-index
-    taskRef:
-      params:
-      - name: name
-        value: ecosystem-cert-preflight-checks
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:00b13d06d17328e105b11619ee4db98b215ca6ac02314a4776aa5fc2a974f9c1
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
Reference: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1740984579022249?thread_ts=1740901637.372379&cid=C04PZ7H0VA8

## Changes:
New pipelines with "ecosystem-cert-preflight-checks" removed since an operator bundle doesn't need it. This solves Conforma check for skipped check. 