### PR TITLE
chore: update go-toolset image SHAs to latest

### DIFF
--- a/pipelines/konflux-build-multi-platform.yaml
+++ b/pipelines/konflux-build-multi-platform.yaml
@@ -123,7 +123,7 @@ spec:
     - description: The base image used to run the unit tests
       name: unit-test-base-image
       type: string
-      default: registry.redhat.io/ubi9/go-toolset@sha256:71f121a44270e46a17a548d6b92096a1a0fb56db44927ad318d095177d6dce4b
+      default: registry.redhat.io/ubi9/go-toolset@sha256:59ec4752cf86f0d0dd240b9e29c64d6ee560c28fc986171e126db1db216a246a
     - default: "false"
       description: Set 'true' to enable sealights
       name: enable-sealights

--- a/tasks/unit-test.yaml
+++ b/tasks/unit-test.yaml
@@ -19,7 +19,7 @@ spec:
     - description: The Go base image used to run the unit tests
       name: BASE_IMAGE
       type: string
-      default: registry.redhat.io/ubi10/go-toolset@sha256:b7f71131f21be923baaaf952309b7940ae7c6a55ca44a7a91460adc6c8afd4de
+      default: registry.redhat.io/ubi10/go-toolset@sha256:ee25ad0e020fd471b921bc13aecc2baa992b1c38c327d0680b9a49070a1b564b
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir


### PR DESCRIPTION
## Summary
- Update ubi9/go-toolset SHA in `pipelines/konflux-build-multi-platform.yaml`
- Update ubi10/go-toolset SHA in `tasks/unit-test.yaml`

Added by Claude.