### PR TITLE
chore: update ubi9 go-toolset to Go 1.26.2 for unit tests

### DIFF
--- a/pipelines/konflux-build-multi-platform.yaml
+++ b/pipelines/konflux-build-multi-platform.yaml
@@ -123,7 +123,7 @@ spec:
     - description: The base image used to run the unit tests
       name: unit-test-base-image
       type: string
-      default: registry.redhat.io/ubi9/go-toolset@sha256:59ec4752cf86f0d0dd240b9e29c64d6ee560c28fc986171e126db1db216a246a
+      default: registry.redhat.io/ubi9/go-toolset@sha256:a2ba4645e7c424b08aa83ed7792e279683b0d33acbc5131b18183fd21e336c55
     - default: "false"
       description: Set 'true' to enable sealights
       name: enable-sealights

--- a/tasks/unit-test.yaml
+++ b/tasks/unit-test.yaml
@@ -19,7 +19,7 @@ spec:
     - description: The Go base image used to run the unit tests
       name: BASE_IMAGE
       type: string
-      default: registry.redhat.io/ubi10/go-toolset@sha256:ee25ad0e020fd471b921bc13aecc2baa992b1c38c327d0680b9a49070a1b564b
+      default: registry.redhat.io/ubi9/go-toolset@sha256:a2ba4645e7c424b08aa83ed7792e279683b0d33acbc5131b18183fd21e336c55
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir


### PR DESCRIPTION
Update BASE_IMAGE and unit-test-base-image